### PR TITLE
Add Nectar object-storage fallback for failed ORAS pulls

### DIFF
--- a/.github/workflows/test_transparent_singularity_cvmfs.sh
+++ b/.github/workflows/test_transparent_singularity_cvmfs.sh
@@ -4,7 +4,7 @@ set -e
 echo "checking if CVMFS part works:"
 
 sudo apt-get install lsb-release
-wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+wget --no-check-certificate https://cvmrepo.web.cern.ch/cvmrepo/apt/cvmfs-release-latest_all.deb
 
 echo "[DEBUG]: adding cfms repo"
 sudo dpkg -i cvmfs-release-latest_all.deb
@@ -27,9 +27,9 @@ NQIDAQAB
 -----END PUBLIC KEY-----" | sudo tee /etc/cvmfs/keys/ardc.edu.au/neurodesk.ardc.edu.au.pub
 
 
-echo "CVMFS_USE_GEOAPI=yes" | sudo tee /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf
+echo "CVMFS_USE_GEOAPI=no" | sudo tee /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf
 
-echo 'CVMFS_SERVER_URL="http://cvmfs.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-brisbane.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-sydney.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-frankfurt.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-zurich.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-toronto.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-ashburn.neurodesk.org/cvmfs/@fqrn@;http://cvmfs.neurodesk.org/cvmfs/@fqrn@"' | sudo tee -a /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf 
+echo 'CVMFS_SERVER_URL="http://cvmfs.neurodesk.org/cvmfs/@fqrn@"' | sudo tee -a /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf 
 
 echo 'CVMFS_KEYS_DIR="/etc/cvmfs/keys/ardc.edu.au/"' | sudo tee -a /etc/cvmfs/config.d/neurodesk.ardc.edu.au.conf
 

--- a/run_transparent_singularity.sh
+++ b/run_transparent_singularity.sh
@@ -14,6 +14,60 @@ fail() {
    exit 2
 }
 
+download_container_from_nectar() {
+   local fallback_container="$1"
+   local nectar_url
+   local nectar_urls=(
+      "https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/neurodesk/temporary-builds-new/"
+      "https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/neurodesk/"
+   )
+
+   if ! command -v curl >/dev/null 2>&1; then
+      echo "[WARN] curl is not available; cannot use Nectar fallback for '${fallback_container}'." >&2
+      return 1
+   fi
+
+   for nectar_url in "${nectar_urls[@]}"; do
+      echo "checking Nectar fallback: ${nectar_url}${fallback_container}"
+      if ! curl --output /dev/null --silent --head --fail "${nectar_url}${fallback_container}"; then
+         continue
+      fi
+
+      echo "downloading from Nectar fallback: ${nectar_url}${fallback_container}"
+      rm -f "$fallback_container"
+      if curl --fail --location --retry 5 --retry-delay 10 \
+            --output "$fallback_container" "${nectar_url}${fallback_container}"; then
+         return 0
+      fi
+      rm -f "$fallback_container"
+   done
+
+   return 1
+}
+
+run_container_pull_with_fallback() {
+   if [[ -z "${container_pull:-}" ]]; then
+      echo "[ERROR] No retrieval command was selected for '${container}'." >&2
+      return 1
+   fi
+
+   echo "running: $container_pull"
+   local pull_status=0
+   $container_pull || pull_status=$?
+   if [[ $pull_status -eq 0 ]]; then
+      return 0
+   fi
+   if [[ "$storage" = "quay-v2" ]] || [[ "$storage" = "ghcr-v2" ]]; then
+      echo "[WARN] ORAS pull failed for '${container}'. Trying Nectar object-storage fallback." >&2
+      if download_container_from_nectar "$container"; then
+         return 0
+      fi
+      echo "[ERROR] ORAS pull failed with status ${pull_status}, and Nectar fallback did not retrieve '${container}'." >&2
+   fi
+
+   return "$pull_status"
+}
+
 export SINGULARITY_BINDPATH=$SINGULARITY_BINDPATH,$PWD
 
 _script="$(readlink -f ${BASH_SOURCE[0]})" ## who am i? ##
@@ -311,8 +365,7 @@ if  [[ -e $container ]]; then
 else
    echo "pulling image now ..."
    echo "where am I: $PWD"
-   echo "running: $container_pull"
-   if ! $container_pull; then
+   if ! run_container_pull_with_fallback; then
       fail "Failed to retrieve container '${container}'."
    fi
 fi
@@ -427,7 +480,7 @@ moduleName=`echo $container | cut -d _ -f 2`
 
 echo "-- -*- lua -*-" > ${modulePath}/${moduleName}.lua
 echo "help([===[" >> ${modulePath}/${moduleName}.lua 
-cat README.md >> ${modulePath}/${moduleName}.lua
+bash "$_base/ts_sanitize_lua_help.sh" README.md >> ${modulePath}/${moduleName}.lua
 echo "]===])" >> ${modulePath}/${moduleName}.lua
 
 echo "whatis(\"${container}\")" >> ${modulePath}/${moduleName}.lua

--- a/ts_sanitize_lua_help.sh
+++ b/ts_sanitize_lua_help.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lmod 6.6 serializes cached help text as a Lua [[...]] long string. Avoid
+# emitting its close delimiter in help text so `ml av` can parse the cache.
+sed 's/]]/] ]/g' "$@"


### PR DESCRIPTION
## Problem

Large SIF pulls via `oras://` from GHCR fail sporadically mid-download with `stream error: stream ID 1; PROTOCOL_ERROR` (seen with `esilpd_0.0.1_20260629`, an 11.7 GiB image that died at 42%). Apptainer's ORAS puller neither resumes nor retries, so the whole install aborts even though the same image sits on Nectar object storage. The Stratum 0 CVMFS sync clones this repo, so the fallback that already existed in the neurocommand copy of this script never ran in production.

## Changes

- Port `download_container_from_nectar` / `run_container_pull_with_fallback` from the neurocommand copy: when a `quay-v2` / `ghcr-v2` ORAS pull fails, download the `.simg` from Nectar (temporary-builds-new bucket, then the standard bucket) before giving up.
- Fix the exit-status capture in the ported code: the status is now taken directly after the pull command, so a failed pull followed by a failed fallback propagates the real status instead of 0.
- Sync `ts_sanitize_lua_help.sh` (used when embedding README content in lua module help) and the CVMFS CI test script, which had also diverged in the neurocommand copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)